### PR TITLE
Dev upgrade elastic search version to 7

### DIFF
--- a/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
+++ b/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
@@ -413,7 +413,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
         protected virtual AnalyzersDescriptor ConfigureAnalyzers(AnalyzersDescriptor analyzers)
         {
             return analyzers
-                .Custom(SearchableFieldAnalyzerName, customAnalyzer => ConfigureSearchableFieldAnalyzer(customAnalyzer));
+                .Custom(SearchableFieldAnalyzerName, ConfigureSearchableFieldAnalyzer);
         }
 
         protected virtual CustomAnalyzerDescriptor ConfigureSearchableFieldAnalyzer(CustomAnalyzerDescriptor customAnalyzer)
@@ -427,8 +427,8 @@ namespace VirtoCommerce.ElasticSearchModule.Data
         protected virtual TokenFiltersDescriptor ConfigureTokenFilters(TokenFiltersDescriptor tokenFilters)
         {
             return tokenFilters
-                .NGram(NGramFilterName, descriptor => ConfigureNGramFilter(descriptor))
-                .EdgeNGram(EdgeNGramFilterName, descriptor => ConfigureEdgeNGramFilter(descriptor));
+                .NGram(NGramFilterName, ConfigureNGramFilter)
+                .EdgeNGram(EdgeNGramFilterName, ConfigureEdgeNGramFilter);
         }
 
         protected virtual NGramTokenFilterDescriptor ConfigureNGramFilter(NGramTokenFilterDescriptor nGram)

--- a/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
+++ b/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
@@ -55,7 +55,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             {
                 var indexName = GetIndexName(documentType);
 
-                var response = await Client.DeleteIndexAsync(indexName);
+                var response = await Client.Indices.DeleteAsync(indexName);
                 if (!response.IsValid && response.ApiCall.HttpStatusCode != 404)
                 {
                     throw new SearchException(response.DebugInformation);
@@ -73,29 +73,29 @@ namespace VirtoCommerce.ElasticSearchModule.Data
         {
             var indexName = GetIndexName(documentType);
 
-            var providerFields = await GetMappingAsync(indexName, documentType);
+            var providerFields = await GetMappingAsync(indexName);
             var oldFieldsCount = providerFields.Count();
 
-            var providerDocuments = documents.Select(document => ConvertToProviderDocument(document, providerFields, documentType)).ToList();
+            var providerDocuments = documents.Select(document => ConvertToProviderDocument(document, providerFields)).ToList();
 
             var updateMapping = providerFields.Count() != oldFieldsCount;
             var indexExits = await IndexExistsAsync(indexName);
 
             if (!indexExits)
             {
-                await CreateIndexAsync(indexName, documentType);
+                await CreateIndexAsync(indexName);
             }
 
             if (!indexExits || updateMapping)
             {
-                await UpdateMappingAsync(indexName, documentType, providerFields);
+                await UpdateMappingAsync(indexName, providerFields);
             }
 
             var bulkDefinition = new BulkDescriptor();
-            bulkDefinition.IndexMany(providerDocuments).Index(indexName).Type(documentType);
+            bulkDefinition.IndexMany(providerDocuments).Index(indexName);
 
             var bulkResponse = await Client.BulkAsync(bulkDefinition);
-            await Client.RefreshAsync(indexName);
+            await Client.Indices.RefreshAsync(indexName);
 
             var result = new IndexingResult
             {
@@ -116,10 +116,10 @@ namespace VirtoCommerce.ElasticSearchModule.Data
 
             var indexName = GetIndexName(documentType);
             var bulkDefinition = new BulkDescriptor();
-            bulkDefinition.DeleteMany(providerDocuments).Index(indexName).Type(documentType);
+            bulkDefinition.DeleteMany(providerDocuments).Index(indexName);
 
             var bulkResponse = await Client.BulkAsync(bulkDefinition);
-            await Client.RefreshAsync(indexName);
+            await Client.Indices.RefreshAsync(indexName);
 
             var result = new IndexingResult
             {
@@ -142,8 +142,8 @@ namespace VirtoCommerce.ElasticSearchModule.Data
 
             try
             {
-                var availableFields = await GetMappingAsync(indexName, documentType);
-                var providerRequest = RequestBuilder.BuildRequest(request, indexName, documentType, availableFields);
+                var availableFields = await GetMappingAsync(indexName);
+                var providerRequest = RequestBuilder.BuildRequest(request, indexName, availableFields);
                 providerResponse = await Client.SearchAsync<SearchDocument>(providerRequest);
             }
             catch (Exception ex)
@@ -156,12 +156,12 @@ namespace VirtoCommerce.ElasticSearchModule.Data
                 ThrowException(providerResponse.DebugInformation, null);
             }
 
-            var result = providerResponse.ToSearchResponse(request, documentType);
+            var result = providerResponse.ToSearchResponse(request);
             return result;
         }
 
 
-        protected virtual SearchDocument ConvertToProviderDocument(IndexDocument document, Properties<IProperties> properties, string documentType)
+        protected virtual SearchDocument ConvertToProviderDocument(IndexDocument document, Properties<IProperties> properties)
         {
             var result = new SearchDocument { Id = document.Id };
 
@@ -194,8 +194,8 @@ namespace VirtoCommerce.ElasticSearchModule.Data
                     if (dictionary != null && !dictionary.ContainsKey(fieldName))
                     {
                         // Create new property mapping
-                        var providerField = CreateProviderField(field, documentType);
-                        ConfigureProperty(providerField, field, documentType);
+                        var providerField = CreateProviderField(field);
+                        ConfigureProperty(providerField, field);
                         properties.Add(fieldName, providerField);
                     }
 
@@ -213,7 +213,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             return result;
         }
 
-        protected virtual IProperty CreateProviderField(IndexDocumentField field, string documentType)
+        protected virtual IProperty CreateProviderField(IndexDocumentField field)
         {
             var fieldType = field.Value?.GetType() ?? typeof(object);
 
@@ -260,7 +260,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             throw new ArgumentException($"Field {field.Name} has unsupported type {fieldType}", nameof(field));
         }
 
-        protected virtual void ConfigureProperty(IProperty property, IndexDocumentField field, string documentType)
+        protected virtual void ConfigureProperty(IProperty property, IndexDocumentField field)
         {
             if (property != null)
             {
@@ -273,18 +273,18 @@ namespace VirtoCommerce.ElasticSearchModule.Data
                 var textProperty = property as TextProperty;
                 if (textProperty != null)
                 {
-                    ConfigureTextProperty(textProperty, field, documentType);
+                    ConfigureTextProperty(textProperty, field);
                 }
 
                 var keywordProperty = property as KeywordProperty;
                 if (keywordProperty != null)
                 {
-                    ConfigureKeywordProperty(keywordProperty, field, documentType);
+                    ConfigureKeywordProperty(keywordProperty, field);
                 }
             }
         }
 
-        protected virtual void ConfigureKeywordProperty(KeywordProperty keywordProperty, IndexDocumentField field, string documentType)
+        protected virtual void ConfigureKeywordProperty(KeywordProperty keywordProperty, IndexDocumentField field)
         {
             if (keywordProperty != null)
             {
@@ -292,7 +292,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             }
         }
 
-        protected virtual void ConfigureTextProperty(TextProperty textProperty, IndexDocumentField field, string documentType)
+        protected virtual void ConfigureTextProperty(TextProperty textProperty, IndexDocumentField field)
         {
             if (textProperty != null)
             {
@@ -301,14 +301,14 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             }
         }
 
-        protected virtual async Task<Properties<IProperties>> GetMappingAsync(string indexName, string documentType)
+        protected virtual async Task<Properties<IProperties>> GetMappingAsync(string indexName)
         {
             var properties = GetMappingFromCache(indexName);
             if (properties == null)
             {
                 if (await IndexExistsAsync(indexName))
                 {
-                    var providerMapping = await Client.GetMappingAsync(new GetMappingRequest(indexName, documentType));
+                    var providerMapping = await Client.Indices.GetMappingAsync(new GetMappingRequest(indexName));
                     var mapping = providerMapping.GetMappingFor(indexName);
                     if (mapping != null)
                     {
@@ -323,9 +323,9 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             return properties;
         }
 
-        protected virtual async Task UpdateMappingAsync(string indexName, string documentType, Properties<IProperties> properties)
+        protected virtual async Task UpdateMappingAsync(string indexName, Properties<IProperties> properties)
         {
-            var mappingRequest = new PutMappingRequest(indexName, documentType) { Properties = properties };
+            var mappingRequest = new PutMappingRequest(indexName) { Properties = properties };
             var response = await Client.MapAsync(mappingRequest);
 
             if (!response.IsValid)
@@ -335,7 +335,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
 
             AddMappingToCache(indexName, properties);
 
-            await Client.RefreshAsync(indexName);
+            await Client.Indices.RefreshAsync(indexName);
         }
 
         protected virtual Properties<IProperties> GetMappingFromCache(string indexName)
@@ -377,58 +377,66 @@ namespace VirtoCommerce.ElasticSearchModule.Data
 
         protected virtual async Task<bool> IndexExistsAsync(string indexName)
         {
-            var response = await Client.IndexExistsAsync(indexName);
+            var response = await Client.Indices.ExistsAsync(indexName);
             return response.Exists;
         }
 
         #region Create and configure index
 
-        protected virtual async Task CreateIndexAsync(string indexName, string documentType)
+        protected virtual async Task CreateIndexAsync(string indexName)
         {
-            await Client.CreateIndexAsync(indexName, i => i.Settings(s => ConfigureIndexSettings(s, documentType)));
+            var response = await Client.Indices.CreateAsync(indexName, i => i.Settings(ConfigureIndexSettings));
+
+            if (!response.IsValid)
+            {
+                ThrowException("Failed to create index. " + response.DebugInformation, response.OriginalException);
+            }
         }
 
-        protected virtual IndexSettingsDescriptor ConfigureIndexSettings(IndexSettingsDescriptor settings, string documentType)
+        protected virtual IndexSettingsDescriptor ConfigureIndexSettings(IndexSettingsDescriptor settings)
         {
             // https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#mapping-limit-settings
             var fieldsLimit = GetFieldsLimit();
 
+            //new v7.3 index setting "max_ngram_diff"
+            //https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index.max_ngram_diff
+            var ngramDiff = GetMaxGram() - GetMinGram();
+
             return settings
                 .Setting("index.mapping.total_fields.limit", fieldsLimit)
+                .Setting("index.max_ngram_diff", ngramDiff)
                 .Analysis(a => a
-                    .TokenFilters(tokenFilters => ConfigureTokenFilters(tokenFilters, documentType))
-                    .Analyzers(analyzers => ConfigureAnalyzers(analyzers, documentType)));
+                    .TokenFilters(ConfigureTokenFilters)
+                    .Analyzers(ConfigureAnalyzers));
         }
 
-        protected virtual AnalyzersDescriptor ConfigureAnalyzers(AnalyzersDescriptor analyzers, string documentType)
+        protected virtual AnalyzersDescriptor ConfigureAnalyzers(AnalyzersDescriptor analyzers)
         {
             return analyzers
-                .Custom(SearchableFieldAnalyzerName, customAnalyzer => ConfigureSearchableFieldAnalyzer(customAnalyzer, documentType));
+                .Custom(SearchableFieldAnalyzerName, customAnalyzer => ConfigureSearchableFieldAnalyzer(customAnalyzer));
         }
 
-        protected virtual CustomAnalyzerDescriptor ConfigureSearchableFieldAnalyzer(CustomAnalyzerDescriptor customAnalyzer, string documentType)
+        protected virtual CustomAnalyzerDescriptor ConfigureSearchableFieldAnalyzer(CustomAnalyzerDescriptor customAnalyzer)
         {
             // Use ngrams analyzer for search in the middle of the word
-            // http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/ngrams-compound-words.html
             return customAnalyzer
                 .Tokenizer("standard")
                 .Filters("lowercase", GetTokenFilterName());
         }
 
-        protected virtual TokenFiltersDescriptor ConfigureTokenFilters(TokenFiltersDescriptor tokenFilters, string documentType)
+        protected virtual TokenFiltersDescriptor ConfigureTokenFilters(TokenFiltersDescriptor tokenFilters)
         {
             return tokenFilters
-                .NGram(NGramFilterName, descriptor => ConfigureNGramFilter(descriptor, documentType))
-                .EdgeNGram(EdgeNGramFilterName, descriptor => ConfigureEdgeNGramFilter(descriptor, documentType))
-                ;
+                .NGram(NGramFilterName, descriptor => ConfigureNGramFilter(descriptor))
+                .EdgeNGram(EdgeNGramFilterName, descriptor => ConfigureEdgeNGramFilter(descriptor));
         }
 
-        protected virtual NGramTokenFilterDescriptor ConfigureNGramFilter(NGramTokenFilterDescriptor nGram, string documentType)
+        protected virtual NGramTokenFilterDescriptor ConfigureNGramFilter(NGramTokenFilterDescriptor nGram)
         {
             return nGram.MinGram(GetMinGram()).MaxGram(GetMaxGram());
         }
 
-        protected virtual EdgeNGramTokenFilterDescriptor ConfigureEdgeNGramFilter(EdgeNGramTokenFilterDescriptor edgeNGram, string documentType)
+        protected virtual EdgeNGramTokenFilterDescriptor ConfigureEdgeNGramFilter(EdgeNGramTokenFilterDescriptor edgeNGram)
         {
             return edgeNGram.MinGram(GetMinGram()).MaxGram(GetMaxGram());
         }

--- a/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
+++ b/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
@@ -466,8 +466,6 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             var pool = new SingleNodeConnectionPool(serverUrl);
             var connectionSettings = new ConnectionSettings(pool, sourceSerializer: JsonNetSerializer.Default);
 
-            connectionSettings.DisableDirectStreaming(true);
-
             if (!string.IsNullOrEmpty(accessUser) && !string.IsNullOrEmpty(accessKey))
             {
                 connectionSettings.BasicAuthentication(accessUser, accessKey);

--- a/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchRequestBuilder.cs
+++ b/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchRequestBuilder.cs
@@ -9,9 +9,9 @@ namespace VirtoCommerce.ElasticSearchModule.Data
 {
     public class ElasticSearchRequestBuilder
     {
-        public virtual ISearchRequest BuildRequest(SearchRequest request, string indexName, string documentType, Properties<IProperties> availableFields)
+        public virtual ISearchRequest BuildRequest(SearchRequest request, string indexName, Properties<IProperties> availableFields)
         {
-            var result = new Nest.SearchRequest(indexName, documentType)
+            var result = new Nest.SearchRequest(indexName)
             {
                 Query = GetQuery(request),
                 PostFilter = GetFilters(request, availableFields),
@@ -76,7 +76,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             }
             else
             {
-                result = new SortField
+                result = new FieldSort
                 {
                     Field = ElasticSearchHelper.ToElasticFieldName(field.FieldName),
                     Order = field.IsDescending ? SortOrder.Descending : SortOrder.Ascending,

--- a/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchRequestBuilder.cs
+++ b/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchRequestBuilder.cs
@@ -154,7 +154,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             var termValues = termFilter.Values;
 
             var field = availableFields.Where(kvp => kvp.Key.Name.EqualsInvariant(termFilter.FieldName)).Select(kvp => kvp.Value).FirstOrDefault();
-            if (field?.Type?.Name?.EqualsInvariant("boolean") == true)
+            if (field?.Type?.EqualsInvariant("boolean") == true)
             {
                 termValues = termValues.Select(v => v.ToLowerInvariant()).ToArray();
             }
@@ -310,10 +310,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
 
                 if (termAggregationRequest.Values?.Any() == true)
                 {
-                    termsAggregation.Include = new TermsIncludeExclude
-                    {
-                        Values = termAggregationRequest.Values
-                    };
+                    termsAggregation.Include = new TermsInclude(termAggregationRequest.Values);
                 }
             }
 

--- a/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchResponseBuilder.cs
+++ b/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchResponseBuilder.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Nest;
 using Newtonsoft.Json.Linq;
 using VirtoCommerce.Domain.Search;
+using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.ElasticSearchModule.Data
 {
@@ -25,7 +26,8 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             var result = new SearchDocument { Id = hit.Id };
 
             // Copy fields and convert JArray to object[]
-            var fields = (IDictionary<string, object>)hit.Source ?? hit.Fields;
+            var fields = (IDictionary<string, object>)hit.Source ?? (IDictionary<string, object>)hit.Fields;
+
             if (fields != null)
             {
                 foreach (var kvp in fields)
@@ -96,9 +98,9 @@ namespace VirtoCommerce.ElasticSearchModule.Data
 
                 if (singleBucketAggregate != null)
                 {
-                    if (singleBucketAggregate.Aggregations != null)
+                    if (singleBucketAggregate.Keys.Any(x => x.EqualsInvariant(responseKey)))
                     {
-                        bucketAggregate = singleBucketAggregate.Aggregations[responseKey] as BucketAggregate;
+                        bucketAggregate = singleBucketAggregate[responseKey] as BucketAggregate;
                     }
                     else if (singleBucketAggregate.DocCount > 0)
                     {

--- a/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchResponseBuilder.cs
+++ b/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchResponseBuilder.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using Nest;
 using Newtonsoft.Json.Linq;
 using VirtoCommerce.Domain.Search;
-using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.ElasticSearchModule.Data
 {
@@ -98,7 +97,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
 
                 if (singleBucketAggregate != null)
                 {
-                    if (singleBucketAggregate.Keys.Any(x => x.EqualsInvariant(responseKey)))
+                    if (singleBucketAggregate.ContainsKey(responseKey))
                     {
                         bucketAggregate = singleBucketAggregate[responseKey] as BucketAggregate;
                     }

--- a/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchResponseBuilder.cs
+++ b/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchResponseBuilder.cs
@@ -9,7 +9,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
 {
     public static class ElasticSearchResponseBuilder
     {
-        public static SearchResponse ToSearchResponse(this ISearchResponse<SearchDocument> response, Domain.Search.SearchRequest request, string documentType)
+        public static SearchResponse ToSearchResponse(this ISearchResponse<SearchDocument> response, Domain.Search.SearchRequest request)
         {
             var result = new SearchResponse
             {

--- a/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
+++ b/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
@@ -32,30 +32,37 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.5.3.0\lib\net46\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.6.8.3\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
-    <Reference Include="Nest, Version=5.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.5.3.0\lib\net46\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.6.8.3\lib\net461\Nest.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Nest.JsonNetSerializer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.JsonNetSerializer.6.8.3\lib\net461\Nest.JsonNetSerializer.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="VirtoCommerce.Domain, Version=2.23.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Domain.2.23.0\lib\net461\VirtoCommerce.Domain.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="VirtoCommerce.Domain, Version=2.24.22.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Domain.2.24.22\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.9.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.9\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.17.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.17\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
+++ b/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
@@ -33,13 +33,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.7.3.1\lib\net461\Elasticsearch.Net.dll</HintPath>
+      <HintPath>..\packages\Elasticsearch.Net.7.4.0\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.7.3.1\lib\net461\Nest.dll</HintPath>
+      <HintPath>..\packages\NEST.7.4.0\lib\net461\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Nest.JsonNetSerializer, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.JsonNetSerializer.7.3.1\lib\net461\Nest.JsonNetSerializer.dll</HintPath>
+      <HintPath>..\packages\NEST.JsonNetSerializer.7.4.0\lib\net461\Nest.JsonNetSerializer.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
+++ b/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
@@ -61,8 +61,8 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.24.22.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Domain.2.24.22\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.17.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.17\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.24.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.24\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
+++ b/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
@@ -32,14 +32,14 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\Elasticsearch.Net.6.8.3\lib\net461\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elasticsearch.Net.7.3.1\lib\net461\Elasticsearch.Net.dll</HintPath>
     </Reference>
-    <Reference Include="Nest, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.6.8.3\lib\net461\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.7.3.1\lib\net461\Nest.dll</HintPath>
     </Reference>
-    <Reference Include="Nest.JsonNetSerializer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
-      <HintPath>..\packages\NEST.JsonNetSerializer.6.8.3\lib\net461\Nest.JsonNetSerializer.dll</HintPath>
+    <Reference Include="Nest.JsonNetSerializer, Version=7.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <HintPath>..\packages\NEST.JsonNetSerializer.7.3.1\lib\net461\Nest.JsonNetSerializer.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/VirtoCommerce.ElasticSearchModule.Data/app.config
+++ b/VirtoCommerce.ElasticSearchModule.Data/app.config
@@ -4,7 +4,7 @@
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
             <dependentAssembly>
                 <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
             </dependentAssembly>
         </assemblyBinding>
     </runtime>

--- a/VirtoCommerce.ElasticSearchModule.Data/packages.config
+++ b/VirtoCommerce.ElasticSearchModule.Data/packages.config
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="5.3.0" targetFramework="net461" />
-  <package id="NEST" version="5.3.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="VirtoCommerce.Domain" version="2.23.0" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.9" targetFramework="net461" />
+  <package id="Elasticsearch.Net" version="6.8.3" targetFramework="net461" />
+  <package id="NEST" version="6.8.3" targetFramework="net461" />
+  <package id="NEST.JsonNetSerializer" version="6.8.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
+  <package id="System.Buffers" version="4.5.0" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net461" />
+  <package id="VirtoCommerce.Domain" version="2.24.22" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.17" targetFramework="net461" />
 </packages>

--- a/VirtoCommerce.ElasticSearchModule.Data/packages.config
+++ b/VirtoCommerce.ElasticSearchModule.Data/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="6.8.3" targetFramework="net461" />
-  <package id="NEST" version="6.8.3" targetFramework="net461" />
-  <package id="NEST.JsonNetSerializer" version="6.8.3" targetFramework="net461" />
+  <package id="Elasticsearch.Net" version="7.3.1" targetFramework="net461" />
+  <package id="NEST" version="7.3.1" targetFramework="net461" />
+  <package id="NEST.JsonNetSerializer" version="7.3.1" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net461" />

--- a/VirtoCommerce.ElasticSearchModule.Data/packages.config
+++ b/VirtoCommerce.ElasticSearchModule.Data/packages.config
@@ -7,5 +7,5 @@
   <package id="System.Buffers" version="4.5.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.24.22" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.17" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.24" targetFramework="net461" />
 </packages>

--- a/VirtoCommerce.ElasticSearchModule.Data/packages.config
+++ b/VirtoCommerce.ElasticSearchModule.Data/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="7.3.1" targetFramework="net461" />
-  <package id="NEST" version="7.3.1" targetFramework="net461" />
-  <package id="NEST.JsonNetSerializer" version="7.3.1" targetFramework="net461" />
+  <package id="Elasticsearch.Net" version="7.4.0" targetFramework="net461" />
+  <package id="NEST" version="7.4.0" targetFramework="net461" />
+  <package id="NEST.JsonNetSerializer" version="7.4.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.1" targetFramework="net461" />

--- a/VirtoCommerce.ElasticSearchModule.Tests/VirtoCommerce.ElasticSearchModule.Tests.csproj
+++ b/VirtoCommerce.ElasticSearchModule.Tests/VirtoCommerce.ElasticSearchModule.Tests.csproj
@@ -58,8 +58,8 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.24.22.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Domain.2.24.22\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.17.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.17\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.24.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.24\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>

--- a/VirtoCommerce.ElasticSearchModule.Tests/VirtoCommerce.ElasticSearchModule.Tests.csproj
+++ b/VirtoCommerce.ElasticSearchModule.Tests/VirtoCommerce.ElasticSearchModule.Tests.csproj
@@ -35,14 +35,14 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=4.1.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Castle.Core.4.1.0\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Moq, Version=4.7.49.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\packages\Moq.4.7.49\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.7.99.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.7.99\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -52,16 +52,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="VirtoCommerce.CoreModule.Search.Tests, Version=2.23.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.CoreModule.Search.Tests.2.23.0-rc4\lib\net461\VirtoCommerce.CoreModule.Search.Tests.dll</HintPath>
+    <Reference Include="VirtoCommerce.CoreModule.Search.Tests, Version=2.24.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.CoreModule.Search.Tests.2.24.21\lib\net461\VirtoCommerce.CoreModule.Search.Tests.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Domain, Version=2.23.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Domain.2.23.0\lib\net461\VirtoCommerce.Domain.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="VirtoCommerce.Domain, Version=2.24.22.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Domain.2.24.22\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.9.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.9\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.17.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.17\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>

--- a/VirtoCommerce.ElasticSearchModule.Tests/app.config
+++ b/VirtoCommerce.ElasticSearchModule.Tests/app.config
@@ -6,6 +6,10 @@
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.7.49.0" newVersion="4.7.49.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/VirtoCommerce.ElasticSearchModule.Tests/packages.config
+++ b/VirtoCommerce.ElasticSearchModule.Tests/packages.config
@@ -5,7 +5,7 @@
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
   <package id="VirtoCommerce.CoreModule.Search.Tests" version="2.24.21" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.24.22" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.17" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.24" targetFramework="net461" />
   <package id="xunit" version="2.2.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net461" />

--- a/VirtoCommerce.ElasticSearchModule.Tests/packages.config
+++ b/VirtoCommerce.ElasticSearchModule.Tests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.1.0" targetFramework="net461" />
-  <package id="Moq" version="4.7.49" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
-  <package id="VirtoCommerce.CoreModule.Search.Tests" version="2.23.0-rc4" targetFramework="net461" />
-  <package id="VirtoCommerce.Domain" version="2.23.0" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.9" targetFramework="net461" />
+  <package id="Castle.Core" version="4.1.1" targetFramework="net461" />
+  <package id="Moq" version="4.7.99" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
+  <package id="VirtoCommerce.CoreModule.Search.Tests" version="2.24.21" targetFramework="net461" />
+  <package id="VirtoCommerce.Domain" version="2.24.22" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.17" targetFramework="net461" />
   <package id="xunit" version="2.2.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net461" />

--- a/VirtoCommerce.ElasticSearchModule.Web/VirtoCommerce.ElasticSearchModule.Web.csproj
+++ b/VirtoCommerce.ElasticSearchModule.Web/VirtoCommerce.ElasticSearchModule.Web.csproj
@@ -22,6 +22,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -57,8 +58,8 @@
     <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -83,13 +84,11 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
-    <Reference Include="VirtoCommerce.Domain, Version=2.23.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Domain.2.23.0\lib\net461\VirtoCommerce.Domain.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="VirtoCommerce.Domain, Version=2.24.22.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Domain.2.24.22\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.9.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.9\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.17.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.17\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/VirtoCommerce.ElasticSearchModule.Web/VirtoCommerce.ElasticSearchModule.Web.csproj
+++ b/VirtoCommerce.ElasticSearchModule.Web/VirtoCommerce.ElasticSearchModule.Web.csproj
@@ -22,7 +22,6 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/VirtoCommerce.ElasticSearchModule.Web/VirtoCommerce.ElasticSearchModule.Web.csproj
+++ b/VirtoCommerce.ElasticSearchModule.Web/VirtoCommerce.ElasticSearchModule.Web.csproj
@@ -62,8 +62,8 @@
       <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.4\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -74,8 +74,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.4\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Drawing" />
@@ -87,8 +87,8 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.24.22.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\VirtoCommerce.Domain.2.24.22\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.17.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.17\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.24.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\VirtoCommerce.Platform.Core.2.13.24\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -147,13 +147,15 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets" Condition="Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\VirtoCommerce.Module.0.12.0\build\VirtoCommerce.Module.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\VirtoCommerce.Module.0.12.0\build\VirtoCommerce.Module.targets'))" />
+    <Error Condition="!Exists('..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSBuildTasks.1.5.0.235\build\MSBuildTasks.targets'))" />
+    <Error Condition="!Exists('..\packages\VirtoCommerce.Module.0.18.0\build\VirtoCommerce.Module.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\VirtoCommerce.Module.0.18.0\build\VirtoCommerce.Module.targets'))" />
   </Target>
-  <Import Project="..\packages\VirtoCommerce.Module.0.12.0\build\VirtoCommerce.Module.targets" Condition="Exists('..\packages\VirtoCommerce.Module.0.12.0\build\VirtoCommerce.Module.targets')" />
+  <Import Project="..\packages\VirtoCommerce.Module.0.18.0\build\VirtoCommerce.Module.targets" Condition="Exists('..\packages\VirtoCommerce.Module.0.18.0\build\VirtoCommerce.Module.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/VirtoCommerce.ElasticSearchModule.Web/Web.config
+++ b/VirtoCommerce.ElasticSearchModule.Web/Web.config
@@ -20,7 +20,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/VirtoCommerce.ElasticSearchModule.Web/Web.config
+++ b/VirtoCommerce.ElasticSearchModule.Web/Web.config
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  For more information on how to configure your ASP.NET application, please visit
-  https://go.microsoft.com/fwlink/?LinkId=169433
-  -->
 <configuration>
-  <system.web>
-    <compilation debug="true" targetFramework="4.6.1" />
-    <httpRuntime targetFramework="4.6.1" />
-  </system.web>
-
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/VirtoCommerce.ElasticSearchModule.Web/Web.config
+++ b/VirtoCommerce.ElasticSearchModule.Web/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=169433
@@ -8,14 +8,7 @@
     <compilation debug="true" targetFramework="4.6.1" />
     <httpRuntime targetFramework="4.6.1" />
   </system.web>
-<system.webServer>
-    <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    </handlers>
-  </system.webServer>
+
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/VirtoCommerce.ElasticSearchModule.Web/module.ignore
+++ b/VirtoCommerce.ElasticSearchModule.Web/module.ignore
@@ -1,3 +1,6 @@
-﻿Elasticsearch.Net.xml
+Elasticsearch.Net.xml
 Nest.xml
 VirtoCommerce.Domain.dll
+Nest.JsonNetSerializer.xml
+System.Buffers.xml
+System.Diagnostics.DiagnosticSource.xml

--- a/VirtoCommerce.ElasticSearchModule.Web/module.ignore
+++ b/VirtoCommerce.ElasticSearchModule.Web/module.ignore
@@ -1,6 +1,6 @@
 Elasticsearch.Net.xml
 Nest.xml
-VirtoCommerce.Domain.dll
 Nest.JsonNetSerializer.xml
 System.Buffers.xml
 System.Diagnostics.DiagnosticSource.xml
+VirtoCommerce.Domain.dll

--- a/VirtoCommerce.ElasticSearchModule.Web/module.manifest
+++ b/VirtoCommerce.ElasticSearchModule.Web/module.manifest
@@ -2,9 +2,9 @@
 <module>
     <id>VirtoCommerce.Elasticsearch</id>
     <version>1.1.2</version>
-    <platformVersion>2.13.9</platformVersion>
+    <platformVersion>2.13.24</platformVersion>
     <dependencies>
-        <dependency id="VirtoCommerce.Core" version="2.23.0" />
+        <dependency id="VirtoCommerce.Core" version="2.24.22" />
     </dependencies>
 
     <title>Elasticsearch module</title>

--- a/VirtoCommerce.ElasticSearchModule.Web/packages.config
+++ b/VirtoCommerce.ElasticSearchModule.Web/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.4" targetFramework="net461" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.4" targetFramework="net461" />
+  <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.24.22" targetFramework="net461" />
-  <package id="VirtoCommerce.Module" version="0.12.0" targetFramework="net461" developmentDependency="true" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.17" targetFramework="net461" />
+  <package id="VirtoCommerce.Module" version="0.18.0" targetFramework="net461" developmentDependency="true" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.24" targetFramework="net461" />
 </packages>

--- a/VirtoCommerce.ElasticSearchModule.Web/packages.config
+++ b/VirtoCommerce.ElasticSearchModule.Web/packages.config
@@ -3,9 +3,9 @@
   <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net461" />
-  <package id="VirtoCommerce.Domain" version="2.23.0" targetFramework="net461" />
+  <package id="VirtoCommerce.Domain" version="2.24.22" targetFramework="net461" />
   <package id="VirtoCommerce.Module" version="0.12.0" targetFramework="net461" developmentDependency="true" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.9" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.17" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
From 5 to 6.8.3

Add JsonNetSerializer as sourceSerializer for ElasticSearch  ConnectionSettings
Because Nest have own private and independent Nest.JArray. If we want do something like this “value is JArray jArray” we must use JsonNetSerializer.

Now get mapping from method not from property
Removed Bucket.Aggregations dictionary
Buckets are dictionary now
Package version update

From 6.8.3 to ElasticSearch 7.3.1

Removed DocumentType
Added new index setting
Renamed types
Updated package version