### PR TITLE
VP-5855: Fix boolean aggregateion property

### DIFF
--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchRequestBuilder.cs
@@ -121,24 +121,31 @@ namespace VirtoCommerce.ElasticSearchModule.Data
                 case IdsFilter idsFilter:
                     result = CreateIdsFilter(idsFilter);
                     break;
+
                 case TermFilter termFilter:
                     result = CreateTermFilter(termFilter, availableFields);
                     break;
+
                 case RangeFilter rangeFilter:
                     result = CreateRangeFilter(rangeFilter);
                     break;
+
                 case GeoDistanceFilter geoDistanceFilter:
                     result = CreateGeoDistanceFilter(geoDistanceFilter);
                     break;
+
                 case NotFilter notFilter:
                     result = CreateNotFilter(notFilter, availableFields);
                     break;
+
                 case AndFilter andFilter:
                     result = CreateAndFilter(andFilter, availableFields);
                     break;
+
                 case OrFilter orFilter:
                     result = CreateOrFilter(orFilter, availableFields);
                     break;
+
                 case WildCardTermFilter wildcardTermFilter:
                     result = CreateWildcardTermFilter(wildcardTermFilter);
                     break;
@@ -175,7 +182,12 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             var field = availableFields.Where(kvp => kvp.Key.Name.EqualsInvariant(termFilter.FieldName)).Select(kvp => kvp.Value).FirstOrDefault();
             if (field?.Type?.EqualsInvariant("boolean") == true)
             {
-                termValues = termValues.Select(v => v.ToLowerInvariant()).ToArray();
+                termValues = termValues.Select(v => v switch
+                {
+                    "1" => "true",
+                    "0" => "false",
+                    _ => v.ToLowerInvariant()
+                }).ToArray();
             }
 
             return new TermsQuery
@@ -184,7 +196,6 @@ namespace VirtoCommerce.ElasticSearchModule.Data
                 Terms = termValues
             };
         }
-
 
         protected virtual QueryContainer CreateRangeFilter(RangeFilter rangeFilter)
         {

--- a/tests/VirtoCommerce.ElasticSearchModule.Tests/ElasticSearchRequestBuilderTests.cs
+++ b/tests/VirtoCommerce.ElasticSearchModule.Tests/ElasticSearchRequestBuilderTests.cs
@@ -9,14 +9,11 @@ using Xunit;
 
 namespace VirtoCommerce.ElasticSearchModule.Tests
 {
+    [Trait("Category", "CI")]
     public class ElasticSearchRequestBuilderTests
     {
         private readonly ElasticSearchRequestBuilderTestProxy _testClass = new ElasticSearchRequestBuilderTestProxy();
         private readonly Fixture _fixture = new Fixture();
-
-        public ElasticSearchRequestBuilderTests()
-        {
-        }
 
         [Theory]
         [InlineData("0", "false")]

--- a/tests/VirtoCommerce.ElasticSearchModule.Tests/ElasticSearchRequestBuilderTests.cs
+++ b/tests/VirtoCommerce.ElasticSearchModule.Tests/ElasticSearchRequestBuilderTests.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using AutoFixture;
+using FluentAssertions;
+using Nest;
+using VirtoCommerce.ElasticSearchModule.Data;
+using VirtoCommerce.SearchModule.Core.Model;
+using Xunit;
+
+namespace VirtoCommerce.ElasticSearchModule.Tests
+{
+    public class ElasticSearchRequestBuilderTests
+    {
+        private readonly ElasticSearchRequestBuilderTestProxy _testClass = new ElasticSearchRequestBuilderTestProxy();
+        private readonly Fixture _fixture = new Fixture();
+
+        public ElasticSearchRequestBuilderTests()
+        {
+        }
+
+        [Theory]
+        [InlineData("0", "false")]
+        [InlineData("1", "true")]
+        [InlineData("true", "true")]
+        [InlineData("false", "false")]
+        [InlineData("tRuE", "true")]
+        [InlineData("FaLsE", "false")]
+        public void CreateTermFilter_BooleanAggregate_ShouldCreateCorrectValues(string value, string convertedValue)
+        {
+            // Arrange
+            var fieldName = _fixture.Create<string>();
+
+            var termFilter = new TermFilter
+            {
+                Values = new[] { value },
+                FieldName = fieldName
+            };
+
+            var availableFields = new Properties<IProperties>(new Dictionary<PropertyName, IProperty>
+            {
+                { fieldName, new BooleanPropertyTestProxy() }
+            });
+
+            // Act
+            var result = _testClass.CreateTermFilterProxy(termFilter, availableFields) as IQueryContainer;
+
+            // Assert
+            result.Terms.Terms.Should().Contain(convertedValue);
+        }
+    }
+
+    public class ElasticSearchRequestBuilderTestProxy : ElasticSearchRequestBuilder
+    {
+        public QueryContainer CreateTermFilterProxy(TermFilter termFilter, Properties<IProperties> availableFields)
+        {
+            return base.CreateTermFilter(termFilter, availableFields);
+        }
+    }
+
+    public class BooleanPropertyTestProxy : IProperty
+    {
+        public IDictionary<string, object> LocalMetadata { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public IDictionary<string, string> Meta { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public PropertyName Name { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string Type { get => "boolean"; set => throw new NotImplementedException(); }
+    }
+}

--- a/tests/VirtoCommerce.ElasticSearchModule.Tests/ElasticSearchRequestBuilderTests.cs
+++ b/tests/VirtoCommerce.ElasticSearchModule.Tests/ElasticSearchRequestBuilderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using AutoFixture;
 using FluentAssertions;
+using Moq;
 using Nest;
 using VirtoCommerce.ElasticSearchModule.Data;
 using VirtoCommerce.SearchModule.Core.Model;
@@ -33,9 +34,14 @@ namespace VirtoCommerce.ElasticSearchModule.Tests
                 FieldName = fieldName
             };
 
+            var booleanPropertyMock = new Mock<IProperty>();
+            booleanPropertyMock
+                .SetupGet(x => x.Type)
+                .Returns("boolean");
+
             var availableFields = new Properties<IProperties>(new Dictionary<PropertyName, IProperty>
             {
-                { fieldName, new BooleanPropertyTestProxy() }
+                { fieldName, booleanPropertyMock.Object }
             });
 
             // Act
@@ -52,13 +58,5 @@ namespace VirtoCommerce.ElasticSearchModule.Tests
         {
             return base.CreateTermFilter(termFilter, availableFields);
         }
-    }
-
-    public class BooleanPropertyTestProxy : IProperty
-    {
-        public IDictionary<string, object> LocalMetadata { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public IDictionary<string, string> Meta { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public PropertyName Name { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public string Type { get => "boolean"; set => throw new NotImplementedException(); }
     }
 }

--- a/tests/VirtoCommerce.ElasticSearchModule.Tests/VirtoCommerce.ElasticSearchModule.Tests.csproj
+++ b/tests/VirtoCommerce.ElasticSearchModule.Tests/VirtoCommerce.ElasticSearchModule.Tests.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.14.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />


### PR DESCRIPTION
Problem:
When a boolean Aggregation property is added, Elasticsearch seems to fail because we send "1" for boolean values in the request.

Solution:
Add the switch case.