### PR TITLE
PT-5080: Update elastic search to 7.15 version

### DIFF
--- a/src/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
@@ -13,9 +13,9 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="Elasticsearch.Net" Version="7.12.1" />
-        <PackageReference Include="NEST" Version="7.12.1" />
-        <PackageReference Include="NEST.JsonNetSerializer" Version="7.12.1" />
+        <PackageReference Include="Elasticsearch.Net" Version="7.15.2" />
+        <PackageReference Include="NEST" Version="7.15.2" />
+        <PackageReference Include="NEST.JsonNetSerializer" Version="7.15.2" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.68.0" />
         <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.15.0" />


### PR DESCRIPTION
## Description
Update elastic search to 7.15 version
## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-5080
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch_3.10.0-pr-32.zip
