### PR TITLE
PT-7121: Add case insensitive normalizer to sort strings in lowercase only

### DIFF
--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
@@ -480,6 +480,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             if (keywordProperty != null)
             {
                 keywordProperty.Index = field.IsFilterable;
+                keywordProperty.Normalizer = "case_insensitive";
             }
         }
 
@@ -489,6 +490,10 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             {
                 textProperty.Index = field.IsSearchable;
                 textProperty.Analyzer = field.IsSearchable ? SearchableFieldAnalyzerName : null;
+                textProperty.Fields = new Properties
+                {
+                    { "keyword", new KeywordProperty() { Normalizer = "case_insensitive" } }
+                };
             }
         }
 
@@ -624,7 +629,10 @@ namespace VirtoCommerce.ElasticSearchModule.Data
                 .Setting("index.max_ngram_diff", ngramDiff)
                 .Analysis(a => a
                     .TokenFilters(ConfigureTokenFilters)
-                    .Analyzers(ConfigureAnalyzers));
+                    .Analyzers(ConfigureAnalyzers)
+                        .Normalizers(n => n
+                            .Custom("case_insensitive", cn => cn
+                                .Filters("lowercase"))));
         }
 
         protected virtual AliasesDescriptor ConfigureAliases(AliasesDescriptor aliases, string alias)

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
@@ -490,10 +490,6 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             {
                 textProperty.Index = field.IsSearchable;
                 textProperty.Analyzer = field.IsSearchable ? SearchableFieldAnalyzerName : null;
-                textProperty.Fields = new Properties
-                {
-                    { "keyword", new KeywordProperty() { Normalizer = "case_insensitive" } }
-                };
             }
         }
 

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchRequestBuilder.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchRequestBuilder.cs
@@ -111,7 +111,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
                     Field = ElasticSearchHelper.ToElasticFieldName(field.FieldName),
                     Order = field.IsDescending ? SortOrder.Descending : SortOrder.Ascending,
                     Missing = "_last",
-                    UnmappedType = FieldType.Long,
+                    UnmappedType = FieldType.Long
                 };
             }
 


### PR DESCRIPTION
## Description
Add case insensitive normalizer to sort strings in lowercase only.
There is a bug when the string values ordered case sensitively (for example, selecting in XAPI):
![image](https://user-images.githubusercontent.com/9972421/170644732-291b7438-80d9-4c6c-897b-5f16276de93b.png)
The change makes case insensitive comparison in sorts:
![image](https://user-images.githubusercontent.com/9972421/170645051-f62b1443-94d6-4127-8df6-a7763bc23f79.png)

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-7121
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch_3.205.0-pr-39.zip
