### PR TITLE
PT-8394 Support Elasticsearch v8.x using the v7.17.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Azure Search provider are configurable by these configuration keys:
 
 [Read more about configuration here](https://virtocommerce.com/docs/user-guide/configuration-settings/)
 
+For Elasticsearch provider v8.x the configuration string must have seven parameters:
+[Read more here](https://www.elastic.co/guide/en/elasticsearch/reference/8.1/configuring-stack-security.html)
+
+```json
+    "Search":{
+        "Provider": "ElasticSearch",
+        "Scope": "default",
+        "ElasticSearch": {
+            "Server": "https://localhost:9200",
+            "UserName": "elastic",
+            "Password": "{SECRET_KEY}",
+            "EnableCompatibilityMode": "true",
+            "CertificateFingerprint": "{CERTIFICATE_FINGERPRINT}"
+         }
+    }
+```
+
 For Elasticsearch provider the configuration string must have three parameters:
 ```json
     "Search":{
@@ -36,7 +53,7 @@ For Elastic Cloud, the configuration string must have four parameters:
         "Scope": "default",
         "ElasticSearch": {
             "Server": "https://4fe3ad462de203c52b358ff2cc6fe9cc.europe-west1.gcp.cloud.es.io:9243",
-            "Key": "{SECRET_KEY}",
+            "Password": "{SECRET_KEY}",
          }
     }
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Azure Search provider are configurable by these configuration keys:
 [Read more about configuration here](https://virtocommerce.com/docs/user-guide/configuration-settings/)
 
 For Elasticsearch provider v8.x the configuration string must have seven parameters:
+Add additional fields **EnableCompatibilityMode** with **true** value for using Elasticsearch v8.x or **false** for earlier version and **CertificateFingerprint** for certificate fingerprint.
 [Read more here](https://www.elastic.co/guide/en/elasticsearch/reference/8.1/configuring-stack-security.html)
 
 ```json
@@ -27,8 +28,8 @@ For Elasticsearch provider v8.x the configuration string must have seven paramet
         "Scope": "default",
         "ElasticSearch": {
             "Server": "https://localhost:9200",
-            "UserName": "elastic",
-            "Password": "{SECRET_KEY}",
+            "User": "elastic",
+            "Key": "{SECRET_KEY}",
             "EnableCompatibilityMode": "true",
             "CertificateFingerprint": "{CERTIFICATE_FINGERPRINT}"
          }
@@ -53,7 +54,7 @@ For Elastic Cloud, the configuration string must have four parameters:
         "Scope": "default",
         "ElasticSearch": {
             "Server": "https://4fe3ad462de203c52b358ff2cc6fe9cc.europe-west1.gcp.cloud.es.io:9243",
-            "Password": "{SECRET_KEY}",
+            "Key": "{SECRET_KEY}",
          }
     }
 ```

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchOptions.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchOptions.cs
@@ -5,8 +5,8 @@ namespace VirtoCommerce.ElasticSearchModule.Data
         public string Server { get; set; }
         public string User { get; set; }
         public string Key { get; set; }
-        public bool EnableHttpCompression { get; set; } = false;
-        public bool EnableCompatibilityMode { get; set; } = false;
+        public bool? EnableHttpCompression { get; set; } = false;
+        public bool? EnableCompatibilityMode { get; set; } = false;
         public string CertificateFingerprint { get; set; }
     }
 }

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchOptions.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchOptions.cs
@@ -3,8 +3,10 @@ namespace VirtoCommerce.ElasticSearchModule.Data
     public class ElasticSearchOptions
     {
         public string Server { get; set; }
-        public string User { get; set; }
-        public string Key { get; set; }
+        public string UserName { get; set; }
+        public string Password { get; set; }
         public string EnableHttpCompression { get; set; }
+        public string EnableCompatibilityMode { get; set; }
+        public string CertificateFingerprint { get; set; }
     }
 }

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchOptions.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchOptions.cs
@@ -3,10 +3,10 @@ namespace VirtoCommerce.ElasticSearchModule.Data
     public class ElasticSearchOptions
     {
         public string Server { get; set; }
-        public string UserName { get; set; }
-        public string Password { get; set; }
-        public string EnableHttpCompression { get; set; }
-        public string EnableCompatibilityMode { get; set; }
+        public string User { get; set; }
+        public string Key { get; set; }
+        public bool EnableHttpCompression { get; set; } = false;
+        public bool EnableCompatibilityMode { get; set; } = false;
         public string CertificateFingerprint { get; set; }
     }
 }

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
@@ -698,22 +698,18 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             var pool = new SingleNodeConnectionPool(serverUrl);
             var connectionSettings = new ConnectionSettings(pool, sourceSerializer: JsonNetSerializer.Default);
 
-            if (!string.IsNullOrEmpty(userName) && !string.IsNullOrEmpty(password))
-            {
-                connectionSettings.BasicAuthentication(userName, password);
-            }
-            else if (!string.IsNullOrEmpty(password))
+            if (!string.IsNullOrEmpty(password))
             {
                 // elastic is default name for elastic cloud
-                connectionSettings.BasicAuthentication("elastic", password);
+                connectionSettings.BasicAuthentication(userName ?? "elastic", password);
             }
 
-            if (options.EnableHttpCompression)
+            if (options.EnableHttpCompression.HasValue && (bool)options.EnableHttpCompression)
             {
                 connectionSettings.EnableHttpCompression();
             }
 
-            if (options.EnableCompatibilityMode)
+            if (options.EnableCompatibilityMode.HasValue && (bool)options.EnableCompatibilityMode)
             {
                 connectionSettings.EnableApiVersioningHeader();
             }

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
@@ -693,8 +693,8 @@ namespace VirtoCommerce.ElasticSearchModule.Data
         protected static IConnectionSettingsValues GetConnectionSettings(ElasticSearchOptions options)
         {
             var serverUrl = GetServerUrl(options);
-            var userName = options.UserName;
-            var password = options.Password;
+            var userName = options.User;
+            var password = options.Key;
             var pool = new SingleNodeConnectionPool(serverUrl);
             var connectionSettings = new ConnectionSettings(pool, sourceSerializer: JsonNetSerializer.Default);
 
@@ -708,12 +708,12 @@ namespace VirtoCommerce.ElasticSearchModule.Data
                 connectionSettings.BasicAuthentication("elastic", password);
             }
 
-            if (options.EnableHttpCompression.EqualsInvariant("true"))
+            if (options.EnableHttpCompression)
             {
                 connectionSettings.EnableHttpCompression();
             }
 
-            if (options.EnableCompatibilityMode.EqualsInvariant("true"))
+            if (options.EnableCompatibilityMode)
             {
                 connectionSettings.EnableApiVersioningHeader();
             }

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
@@ -693,24 +693,34 @@ namespace VirtoCommerce.ElasticSearchModule.Data
         protected static IConnectionSettingsValues GetConnectionSettings(ElasticSearchOptions options)
         {
             var serverUrl = GetServerUrl(options);
-            var accessUser = options.User;
-            var accessKey = options.Key;
+            var userName = options.UserName;
+            var password = options.Password;
             var pool = new SingleNodeConnectionPool(serverUrl);
             var connectionSettings = new ConnectionSettings(pool, sourceSerializer: JsonNetSerializer.Default);
 
-            if (!string.IsNullOrEmpty(accessUser) && !string.IsNullOrEmpty(accessKey))
+            if (!string.IsNullOrEmpty(userName) && !string.IsNullOrEmpty(password))
             {
-                connectionSettings.BasicAuthentication(accessUser, accessKey);
+                connectionSettings.BasicAuthentication(userName, password);
             }
-            else if (!string.IsNullOrEmpty(accessKey))
+            else if (!string.IsNullOrEmpty(password))
             {
                 // elastic is default name for elastic cloud
-                connectionSettings.BasicAuthentication("elastic", accessKey);
+                connectionSettings.BasicAuthentication("elastic", password);
             }
 
             if (options.EnableHttpCompression.EqualsInvariant("true"))
             {
                 connectionSettings.EnableHttpCompression();
+            }
+
+            if (options.EnableCompatibilityMode.EqualsInvariant("true"))
+            {
+                connectionSettings.EnableApiVersioningHeader();
+            }
+
+            if (!string.IsNullOrEmpty(options.CertificateFingerprint))
+            {
+                connectionSettings.CertificateFingerprint(options.CertificateFingerprint);
             }
 
             return connectionSettings;

--- a/src/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-        <PackageReference Include="Elasticsearch.Net" Version="7.15.2" />
+        <PackageReference Include="Elasticsearch.Net" Version="7.17.4" />
         <PackageReference Include="NEST" Version="7.15.2" />
         <PackageReference Include="NEST.JsonNetSerializer" Version="7.15.2" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
#PT-8394 Support Elasticsearch v8.x using the v7.17.x

## Description
Added settings to support Elasticsearch v8.x.

**Note:** Virto Commerce recommends using Elasticsearch v7.x on production environments for the next 6 months at least. But if either partner or customer wants to use Elasticsearch v8.x they can configure connections string. 

## References
### QA-test:
### Jira-link:


 https://virtocommerce.atlassian.net/browse/PT-8394
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch_3.206.0-pr-42.zip
