### PR TITLE
PT-9197: Introduce ElasticHealthChecker, add timeout tuning options

### DIFF
--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchClient.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchClient.cs
@@ -6,6 +6,6 @@ public class ElasticSearchClient : ElasticClient
 {
     public ElasticSearchClient(IConnectionSettingsValues connectionSettingsValues)
         : base(connectionSettingsValues)
-    {
+    {        
     }
 }

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchConnectionSettings.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchConnectionSettings.cs
@@ -35,8 +35,8 @@ public class ElasticSearchConnectionSettings : ConnectionSettings
         {
             CertificateFingerprint(options.CertificateFingerprint);
         }
+
         RequestTimeout(TimeSpan.FromSeconds(options.RequestTimeout));
-        
     }
 
     protected static IConnectionPool GetConnectionPool(ElasticSearchOptions options)

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchConnectionSettings.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchConnectionSettings.cs
@@ -35,6 +35,8 @@ public class ElasticSearchConnectionSettings : ConnectionSettings
         {
             CertificateFingerprint(options.CertificateFingerprint);
         }
+        RequestTimeout(TimeSpan.FromSeconds(options.RequestTimeout));
+        
     }
 
     protected static IConnectionPool GetConnectionPool(ElasticSearchOptions options)

--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchOptions.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchOptions.cs
@@ -8,5 +8,15 @@ namespace VirtoCommerce.ElasticSearchModule.Data
         public bool? EnableHttpCompression { get; set; } = false;
         public bool? EnableCompatibilityMode { get; set; } = false;
         public string CertificateFingerprint { get; set; }
+
+        /// <summary>
+        /// Sets the default timeout in seconds for each request to Elasticsearch. Defaults to 60 seconds.
+        /// </summary>
+        public int RequestTimeout { get; set; } = 60;
+
+        /// <summary>
+        /// Sets the default timeout in seconds for health checking pings to Elasticsearch. Defaults to 2 seconds
+        /// </summary>
+        public int HealthCheckTimeout { get; set; } = 2;
     }
 }

--- a/src/VirtoCommerce.ElasticSearchModule.Web/Infrastructure/ElasticHealthChecker.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Web/Infrastructure/ElasticHealthChecker.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Nest;
+using VirtoCommerce.ElasticSearchModule.Data;
+
+namespace VirtoCommerce.ElasticSearchModule.Web.Infrastructure
+{
+    public class ElasticHealthChecker : IHealthCheck
+    {
+        private readonly IElasticClient _elasticClient;
+        private readonly ElasticSearchOptions _elasticSearchOptions;
+
+        public ElasticHealthChecker(IElasticClient elasticClient, IOptions<ElasticSearchOptions> elasticSearchOptions)
+        {
+            _elasticClient = elasticClient;
+            _elasticSearchOptions = elasticSearchOptions.Value;
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+        {
+            // Use different timeout for the healthchecking pings. Otherwise ping will hangs on default timeout so much longer (default is minute and more).
+            var pingResult = await _elasticClient.PingAsync(
+                new PingRequest() { RequestConfiguration = new RequestConfiguration() { RequestTimeout = TimeSpan.FromSeconds(_elasticSearchOptions.HealthCheckTimeout) } });
+            if (pingResult.IsValid)
+            {
+                return HealthCheckResult.Healthy("Elastic server is reachable");
+            }
+            else
+            {
+                return HealthCheckResult.Unhealthy(@$"No connection to Elastic-server.{Environment.NewLine}{pingResult.ApiCall.DebugInformation}");
+            }
+        }
+    }
+}

--- a/src/VirtoCommerce.ElasticSearchModule.Web/Infrastructure/ElasticHealthChecker.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Web/Infrastructure/ElasticHealthChecker.cs
@@ -24,7 +24,8 @@ namespace VirtoCommerce.ElasticSearchModule.Web.Infrastructure
         {
             // Use different timeout for the healthchecking pings. Otherwise ping will hangs on default timeout so much longer (default is minute and more).
             var pingResult = await _elasticClient.PingAsync(
-                new PingRequest() { RequestConfiguration = new RequestConfiguration() { RequestTimeout = TimeSpan.FromSeconds(_elasticSearchOptions.HealthCheckTimeout) } });
+                new PingRequest() { RequestConfiguration = new RequestConfiguration() { RequestTimeout = TimeSpan.FromSeconds(_elasticSearchOptions.HealthCheckTimeout) } },
+                cancellationToken);
             if (pingResult.IsValid)
             {
                 return HealthCheckResult.Healthy("Elastic server is reachable");

--- a/src/VirtoCommerce.ElasticSearchModule.Web/Module.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Web/Module.cs
@@ -38,7 +38,7 @@ namespace VirtoCommerce.ElasticSearchModule.Web
                 serviceCollection.AddSingleton<IConnectionSettingsValues, ElasticSearchConnectionSettings>();
                 serviceCollection.AddSingleton<IElasticClient, ElasticSearchClient>();
                 serviceCollection.AddSingleton<ISearchProvider, ElasticSearchProvider>();
-                serviceCollection.AddHealthChecks().AddCheck<ElasticHealthChecker>("elastic_health_checker", tags: new string[] { "Modules", "Elastic" });
+                serviceCollection.AddHealthChecks().AddCheck<ElasticHealthChecker>("Elastic server connection", tags: new string[] { "Modules", "Elastic" });
             }
         }
 

--- a/src/VirtoCommerce.ElasticSearchModule.Web/Module.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Web/Module.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nest;
 using VirtoCommerce.ElasticSearchModule.Data;
+using VirtoCommerce.ElasticSearchModule.Web.Infrastructure;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Settings;
@@ -36,6 +38,7 @@ namespace VirtoCommerce.ElasticSearchModule.Web
                 serviceCollection.AddSingleton<IConnectionSettingsValues, ElasticSearchConnectionSettings>();
                 serviceCollection.AddSingleton<IElasticClient, ElasticSearchClient>();
                 serviceCollection.AddSingleton<ISearchProvider, ElasticSearchProvider>();
+                serviceCollection.AddHealthChecks().AddCheck<ElasticHealthChecker>("elastic_health_checker", tags: new string[] { "Modules", "Elastic" });
             }
         }
 


### PR DESCRIPTION
## Description
Introduce ElasticHealthChecker and timeout tuning options

The note, recently to startup issues in case of unreachable Elastic-server:

When the platform is running locally, the process hangs for elastic connection timeout, then continues to work.
In real circumstances, the pod is killing by the host (kubernetes) if the platform process is unhealthy.
I think, the host declares the pod unhealthy due to long default elastic connection timeout (60s).

I’ve added options to tune the timeout. Also, I recommend increasing the timeout used by the host to checking the platform process.

Two elastic options have added:

* _RequestTimeout_  -- Sets the default timeout in seconds for each request to Elasticsearch. Defaults to 60 seconds. 

* _HealthCheckTimeout_ -- Sets the default timeout in seconds for health checking pings to Elasticsearch. Defaults to 2 seconds
## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/PT-9197
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch_3.209.0-pr-45-9c56.zip
