### PR TITLE
Add CLR error message from ElasticSearch

### DIFF
--- a/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/ElasticSearchProvider.cs
@@ -26,7 +26,7 @@ namespace VirtoCommerce.ElasticSearchModule.Data
         public const string NGramFilterName = "custom_ngram";
         public const string EdgeNGramFilterName = "custom_edge_ngram";
 
-        private const string _exceptionTitle = "CLR Exception";
+        private const string _exceptionTitle = "Elasticsearch Server";
 
         private readonly ConcurrentDictionary<string, Properties<IProperties>> _mappings = new ConcurrentDictionary<string, Properties<IProperties>>();
         private readonly SearchOptions _searchOptions;
@@ -283,12 +283,12 @@ namespace VirtoCommerce.ElasticSearchModule.Data
             var result = new IndexingResult();
             result.Items = new List<IndexingResultItem>();
 
-            if (!bulkResponse.IsValid && bulkResponse.OriginalException != null)
+            if (!bulkResponse.IsValid)
             {
                 result.Items.Add(new IndexingResultItem
                 {
                     Id = _exceptionTitle,
-                    ErrorMessage = bulkResponse.OriginalException.Message,
+                    ErrorMessage = bulkResponse.OriginalException?.Message,
                     Succeeded = false
                 });
             }


### PR DESCRIPTION
## Description
Currently there is no message if any CLR exception occurs during Indexation create/update. 

UI:
![image](https://user-images.githubusercontent.com/2816674/201202950-cfc8e969-034a-4d50-af76-a51c5c3a8b27.png)


However, perhaps better aproach would be enable .ThrowExceptions() options for Provider, but this need proper testsing.  

## References
https://github.com/elastic/elasticsearch-net/issues/1793

### QA-test:
### Jira-link:
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch_3.210.0-pr-46-172f.zip
