### PR TITLE
PT-14218: Support different search provider for each document type

### DIFF
--- a/src/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
@@ -17,6 +17,6 @@
         <PackageReference Include="NEST" Version="7.15.2" />
         <PackageReference Include="NEST.JsonNetSerializer" Version="7.15.2" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.400.0" />
-        <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.401.0" />
+        <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.723-pt-14218" />
     </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
+++ b/src/VirtoCommerce.ElasticSearchModule.Data/VirtoCommerce.ElasticSearchModule.Data.csproj
@@ -17,6 +17,6 @@
         <PackageReference Include="NEST" Version="7.15.2" />
         <PackageReference Include="NEST.JsonNetSerializer" Version="7.15.2" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.400.0" />
-        <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0-alpha.723-pt-14218" />
+        <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.403.0" />
     </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ElasticSearchModule.Web/Module.cs
+++ b/src/VirtoCommerce.ElasticSearchModule.Web/Module.cs
@@ -1,17 +1,15 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nest;
 using VirtoCommerce.ElasticSearchModule.Data;
 using VirtoCommerce.ElasticSearchModule.Web.Infrastructure;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.SearchModule.Core.Extensions;
 using VirtoCommerce.SearchModule.Core.Model;
-using VirtoCommerce.SearchModule.Core.Services;
 
 namespace VirtoCommerce.ElasticSearchModule.Web
 {
@@ -20,26 +18,14 @@ namespace VirtoCommerce.ElasticSearchModule.Web
         public ManifestModuleInfo ModuleInfo { get; set; }
         public IConfiguration Configuration { get; set; }
 
-        private bool IsElasticEnabled
-        {
-            get
-            {
-                var provider = Configuration.GetValue<string>("Search:Provider");
-                return provider.EqualsInvariant("ElasticSearch");
-            }
-        }
-
         public void Initialize(IServiceCollection serviceCollection)
         {
-            if (IsElasticEnabled)
-            {
-                serviceCollection.Configure<ElasticSearchOptions>(Configuration.GetSection("Search:ElasticSearch"));
-                serviceCollection.AddTransient<ElasticSearchRequestBuilder>();
-                serviceCollection.AddSingleton<IConnectionSettingsValues, ElasticSearchConnectionSettings>();
-                serviceCollection.AddSingleton<IElasticClient, ElasticSearchClient>();
-                serviceCollection.AddSingleton<ISearchProvider, ElasticSearchProvider>();
-                serviceCollection.AddHealthChecks().AddCheck<ElasticHealthChecker>("Elastic server connection", tags: new string[] { "Modules", "Elastic" });
-            }
+            serviceCollection.Configure<ElasticSearchOptions>(Configuration.GetSection("Search:ElasticSearch"));
+            serviceCollection.AddTransient<ElasticSearchRequestBuilder>();
+            serviceCollection.AddSingleton<IConnectionSettingsValues, ElasticSearchConnectionSettings>();
+            serviceCollection.AddSingleton<IElasticClient, ElasticSearchClient>();
+            serviceCollection.AddSingleton<ElasticSearchProvider>();
+            serviceCollection.AddHealthChecks().AddCheck<ElasticHealthChecker>("Elastic server connection", tags: new[] { "Modules", "Elastic" });
         }
 
         public void PostInitialize(IApplicationBuilder appBuilder)
@@ -47,14 +33,10 @@ namespace VirtoCommerce.ElasticSearchModule.Web
             var settingsRegistrar = appBuilder.ApplicationServices.GetRequiredService<ISettingsRegistrar>();
             settingsRegistrar.RegisterSettings(ModuleConstants.Settings.AllSettings, ModuleInfo.Id);
 
-            if (IsElasticEnabled)
-            {
-                var documentConfigs = appBuilder.ApplicationServices.GetRequiredService<IEnumerable<IndexDocumentConfiguration>>();
-                var documentTypes = documentConfigs.Select(c => c.DocumentType).Distinct().ToList();
-
-                var provider = appBuilder.ApplicationServices.GetRequiredService<ISearchProvider>();
-                ((ElasticSearchProvider)provider).AddActiveAlias(documentTypes);
-            }
+            var provider = appBuilder.UseSearchProvider<ElasticSearchProvider>("ElasticSearch");
+            var documentConfigs = appBuilder.ApplicationServices.GetRequiredService<IEnumerable<IndexDocumentConfiguration>>();
+            var documentTypes = documentConfigs.Select(c => c.DocumentType).Distinct();
+            provider.AddActiveAlias(documentTypes);
         }
 
         public void Uninstall()

--- a/src/VirtoCommerce.ElasticSearchModule.Web/module.manifest
+++ b/src/VirtoCommerce.ElasticSearchModule.Web/module.manifest
@@ -1,12 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.ElasticSearch</id>
   <version>3.401.0</version>
   <version-tag />
+
   <platformVersion>3.400.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Search" version="3.401.0" />
+    <dependency id="VirtoCommerce.Search" version="3.403.0" />
   </dependencies>
+
   <title>Elastic Search</title>
   <description>Indexed search functionality with Elasticsearch and OpenSearch engines</description>
   <authors>


### PR DESCRIPTION
## Description
Configuration example for default provider `ElasticAppSearch` and category provider `ElasticSearch8`:
```
{
  "Search": {
    "Provider": "ElasticAppSearch",
    "DocumentScopes": [
      {
        "DocumentType": "Category",
        "Provider": "ElasticSearch8"
      }
    ]
  }
}
```
## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/PT-14218
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.ElasticSearch_3.401.0-pr-55-a148.zip
